### PR TITLE
Add PyQt5-sip to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 PyQt5==5.12.2
+PyQt5-sip==12.11.0
 pyln-client>=0.8.2


### PR DESCRIPTION
Otherwise (on Ubuntu 22.04) loading the plugin fails with:
```
Traceback (most recent call last):
  File "/home/igor/.lightning/plugins/lightning-qt/lightning-qt.py", line 13, in <module>
    import sip
ModuleNotFoundError: No module named 'sip'

```